### PR TITLE
Do not send tags on PutParameter, add test

### DIFF
--- a/pkg/resource/parameter/sdk.go
+++ b/pkg/resource/parameter/sdk.go
@@ -267,6 +267,10 @@ func (rm *resourceManager) sdkUpdate(
 	// This follows what the rds controller implements but using hooks to avoid the Overwrite field from being added to the api Spec
 	// https://github.com/aws-controllers-k8s/rds-controller/blob/2d5427a8b4a2f6caf0bc889754370a6ab55dc135/generator.yaml#L103
 	input.Overwrite = aws.Bool(true)
+	// SSM PutParameter rejects requests that include both Tags and Overwrite.
+	// Tags are only accepted on initial creation; updates must use
+	// AddTagsToResource / RemoveTagsFromResource instead.
+	input.Tags = nil
 
 	var resp *svcsdk.PutParameterOutput
 	_ = resp

--- a/templates/hooks/parameter/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/parameter/sdk_update_post_build_request.go.tpl
@@ -3,3 +3,7 @@
 	// This follows what the rds controller implements but using hooks to avoid the Overwrite field from being added to the api Spec
 	// https://github.com/aws-controllers-k8s/rds-controller/blob/2d5427a8b4a2f6caf0bc889754370a6ab55dc135/generator.yaml#L103
 	input.Overwrite = aws.Bool(true)
+	// SSM PutParameter rejects requests that include both Tags and Overwrite.
+	// Tags are only accepted on initial creation; updates must use
+	// AddTagsToResource / RemoveTagsFromResource instead.
+	input.Tags = nil

--- a/test/e2e/resources/parameter_with_tags.yaml
+++ b/test/e2e/resources/parameter_with_tags.yaml
@@ -1,0 +1,14 @@
+apiVersion: ssm.services.k8s.aws/v1alpha1
+kind: Parameter
+metadata:
+  name: $NAME
+spec:
+  name: $PARAMETER_NAME
+  type: String
+  value: $PARAMETER_VALUE
+  description: Test parameter with tags created by e2e tests
+  tags:
+    - key: Environment
+      value: test
+    - key: ManagedBy
+      value: ack-e2e

--- a/test/e2e/tests/test_parameter.py
+++ b/test/e2e/tests/test_parameter.py
@@ -52,6 +52,43 @@ def simple_parameter():
 
 
 @pytest.fixture(scope="module")
+def tagged_parameter():
+    RESOURCE_NAME = random_suffix_name("tagged-param", 24)
+    PARAMETER_NAME = f"/ack-test/{RESOURCE_NAME}"
+
+    resources = get_bootstrap_resources()
+    logging.debug(resources)
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["NAME"] = RESOURCE_NAME
+    replacements["PARAMETER_NAME"] = PARAMETER_NAME
+    replacements["PARAMETER_VALUE"] = "initial-value"
+
+    resource_data = load_ssm_resource("parameter_with_tags", additional_replacements=replacements)
+
+    reference = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        RESOURCE_PLURAL,
+        RESOURCE_NAME,
+        namespace='default',
+    )
+
+    k8s.create_custom_resource(reference, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(reference)
+
+    logging.debug(cr)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(reference)
+    yield reference, cr, PARAMETER_NAME
+
+    _, deleted = k8s.delete_custom_resource(reference)
+    time.sleep(DELETE_WAIT_AFTER_SECONDS)
+    assert deleted is True
+
+
+@pytest.fixture(scope="module")
 def secure_parameter():
     RESOURCE_NAME = random_suffix_name("secure-param", 24)
     PARAMETER_NAME = f"/ack-test/secure/{RESOURCE_NAME}"
@@ -169,6 +206,38 @@ class TestParameter:
         # Verify status fields are populated
         assert 'status' in cr
         assert 'ackResourceMetadata' in cr["status"]
+
+    def test_update_parameter_with_tags(self, tagged_parameter):
+        """Regression test: PutParameter with Overwrite=true must not include
+        Tags in the request, otherwise the SSM API returns:
+        'Invalid request: tags and overwrite can't be used together.'
+        """
+        (reference, _, param_name) = tagged_parameter
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=10)
+
+        cr = k8s.get_resource(reference)
+        assert cr is not None
+        assert cr["spec"]["value"] == "initial-value"
+        assert cr["spec"]["tags"] is not None
+        assert len(cr["spec"]["tags"]) == 2
+
+        # Update the value — this triggers PutParameter with Overwrite=true.
+        # Before the fix, the controller also sent Tags in the same request,
+        # causing the SSM API to reject it.
+        update_data = {
+            "spec": {
+                "value": "updated-value-with-tags"
+            }
+        }
+
+        k8s.patch_custom_resource(reference, update_data)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=10)
+
+        updated_cr = k8s.get_resource(reference)
+        assert updated_cr["spec"]["value"] == "updated-value-with-tags"
 
     def test_update_secure_parameter_value(self, secure_parameter):
         (reference, _, param_name) = secure_parameter


### PR DESCRIPTION
## Observed problem 

When a parameter does not exist, the SSM API's PutParameter method creates it, including tags and other metadata.

However, when the parameter already exists, PutParameter, when the `overwrite=true` option is included, creates a new version of the parameter with an updated value, but does not allow tags to be included in the same request.

This results in failed calls to the AWS API: 
```
{"level":"error","ts":"2026-06-30T00:00:00.000Z","msg":"Reconciler error","controller":"parameter","controllerGroup":"ssm.services.k8s.aws","controllerKind":"Parameter","Parameter":{"name":"XXXXX","namespace":"XXXXX"},"namespace":"XXXXX","name":"XXXXX","reconcileID":"XXXXX","error":"operation error SSM: PutParameter, https response error StatusCode: 400, RequestID: XXXXX, api error ValidationException: Invalid request: tags and overwrite can't be used together. To create a parameter with tags, please remove overwrite flag. To update tags for an existing parameter, please use AddTagsToResource or RemoveTagsFromResource.","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/internal/controller/controller.go:495\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/internal/controller/controller.go:438\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/internal/controller/controller.go:313"}
```

This can also be seen in the CRD:
```
Status:
  Ack Resource Metadata:
    Arn:               arn:aws:ssm:us-east-X:012345678909:parameter/ack-test/tagged-param-xi3ykltgg8k
    Owner Account Id:  012345678909
    Region:            us-east-X
  Conditions:
    Message:               api error ValidationException: Invalid request: tags and overwrite can't be used together. To create a parameter with tags, please remove overwrite flag. To update tags for an existing parameter, please use AddTagsToResource or RemoveTagsFromResource.
    Status:                True
    Type:                  ACK.Recoverable
    Last Transition Time:  2026-06-30T21:23:10Z
    Message:               Unable to determine if desired resource state matches latest observed state
    Reason:                operation error SSM: PutParameter, https response error StatusCode: 400, RequestID: ec8bac29-f631-4c4e-a4d3-64bfb9d1dc16, api error ValidationException: Invalid request: tags and overwrite can't be used together. To create a parameter with tags, please remove overwrite flag. To update tags for an existing parameter, please use AddTagsToResource or RemoveTagsFromResource.
    Status:                Unknown
    Type:                  ACK.ResourceSynced
    Last Transition Time:  2026-06-30T21:23:10Z
    Message:               api error ValidationException: Invalid request: tags and overwrite can't be used together. To create a parameter with tags, please remove overwrite flag. To update tags for an existing parameter, please use AddTagsToResource or RemoveTagsFromResource.
    Reason:                ACK.Recoverable
    Status:                False
    Type:                  Ready
  Version:                 1
Events:                    <none>
```

## Proposed solution

There are already separate paths defined (`sdkCreate`+`newCreateRequestPayload` and `sdkUpdate`+`newUpdateRequestPayload`) in place to accommodate this behavioral quirk, specifically to ensure the `overwrite = true` flag required by the SSM API is present on updates.

This change builds on that and simply excludes the tags from the payload when running an update.

It also adds a test for this condition.

## Testing

1. Container builds successfully using the `ack/code-generator/scripts/build-controller-image.sh` as expected; when deployed, parameter updates flow as expected: ```{"level":"info","ts":"2026-06-30T20:55:13.269Z","logger":"ackrt","msg":"desired resource state has changed","kind":"Parameter","namespace":"XXXXXX","name":"XXXXXX","account":"012345678909","role":"","region":"us-west-X","is_adopted":false,"generation":4,"diff":[{"Path":{"Parts":["Spec","Value"]},"A":"8000","B":"3000"}]}```

2. Running the new test against the 1.4.2 image hangs for longer than I wanted to wait, but results in the CRD I pasted above

3. Running the new test against the updated image results in the expected CRD (this shows two separate `describes`, note that version 1 has tags, then it is updated to version 2, with the tags unchanged):
```
user ~$ k -n default describe parameters tagged-param-ycolmwtvf7m
Name:         tagged-param-ycolmwtvf7m
Namespace:    default
Labels:       <none>
Annotations:  <none>
API Version:  ssm.services.k8s.aws/v1alpha1
Kind:         Parameter
Metadata:
  Creation Timestamp:  2026-06-30T21:25:21Z
  Finalizers:
    finalizers.ssm.services.k8s.aws/Parameter
  Generation:        3
  Resource Version:  42812746
  UID:               7f336ac7-1462-4b36-9ab3-0425d8c81c71
Spec:
  Data Type:    text
  Description:  Test parameter with tags created by e2e tests
  Name:         /ack-test/tagged-param-ycolmwtvf7m
  Tags:
    Key:    Environment
    Value:  test
    Key:    ManagedBy
    Value:  ack-e2e
  Tier:     Standard
  Type:     String
  Value:    initial-value
Status:
  Ack Resource Metadata:
    Arn:               arn:aws:ssm:us-west-X:012345678909:parameter/ack-test/tagged-param-ycolmwtvf7m
    Owner Account Id:  012345678909
    Region:            us-west-X
  Conditions:
    Last Transition Time:  2026-06-30T21:25:21Z
    Message:               Late initialization successful
    Reason:                Late initialization successful
    Status:                True
    Type:                  ACK.LateInitialized
    Last Transition Time:  2026-06-30T21:25:21Z
    Message:               Resource synced successfully
    Reason:
    Status:                True
    Type:                  ACK.ResourceSynced
    Last Transition Time:  2026-06-30T21:25:21Z
    Message:               Resource synced successfully
    Reason:
    Status:                True
    Type:                  Ready
  Version:                 1
Events:                    <none>
user ~$ k -n default describe parameters tagged-param-ycolmwtvf7m
Name:         tagged-param-ycolmwtvf7m
Namespace:    default
Labels:       <none>
Annotations:  <none>
API Version:  ssm.services.k8s.aws/v1alpha1
Kind:         Parameter
Metadata:
  Creation Timestamp:  2026-06-30T21:25:21Z
  Finalizers:
    finalizers.ssm.services.k8s.aws/Parameter
  Generation:        4
  Resource Version:  42812893
  UID:               7f336ac7-1462-4b36-9ab3-0425d8c81c71
Spec:
  Data Type:    text
  Description:  Test parameter with tags created by e2e tests
  Name:         /ack-test/tagged-param-ycolmwtvf7m
  Tags:
    Key:    Environment
    Value:  test
    Key:    ManagedBy
    Value:  ack-e2e
  Tier:     Standard
  Type:     String
  Value:    updated-value-with-tags
Status:
  Ack Resource Metadata:
    Arn:               arn:aws:ssm:us-west-X:012345678909:parameter/ack-test/tagged-param-ycolmwtvf7m
    Owner Account Id:  012345678909
    Region:            us-west-X
  Conditions:
    Last Transition Time:  2026-06-30T21:25:47Z
    Message:               Late initialization successful
    Reason:                Late initialization successful
    Status:                True
    Type:                  ACK.LateInitialized
    Last Transition Time:  2026-06-30T21:25:47Z
    Message:               Resource synced successfully
    Reason:
    Status:                True
    Type:                  ACK.ResourceSynced
    Last Transition Time:  2026-06-30T21:25:47Z
    Message:               Resource synced successfully
    Reason:
    Status:                True
    Type:                  Ready
  Version:                 2
Events:                    <none>
```

4. New unit test passes on the CLI:
```
(pyenv3) ~/external_code/ack/ssm-controller$ pytest test/e2e/tests/test_parameter.py::TestParameter::test_update_parameter_with_tags -v
============================================================================ test session starts =============================================================================
platform darwin -- Python 3.11.14, pytest-9.1.1, pluggy-1.6.0 -- /Users/user/.pyenv/versions/3.11.14/envs/pyenv3/bin/python
cachedir: .pytest_cache
rootdir: /Users/user/external_code/ack/ssm-controller
plugins: xdist-3.5.0
collected 1 item

test/e2e/tests/test_parameter.py::TestParameter::test_update_parameter_with_tags

PASSED                                                                                [100%]


============================================================================== warnings summary ==============================================================================
test/e2e/tests/test_parameter.py::TestParameter::test_update_parameter_with_tags
  /Users/user/.pyenv/versions/3.11.14/envs/pyenv3/lib/python3.11/site-packages/kubernetes/client/rest.py:44: DeprecationWarning: HTTPResponse.getheaders() is deprecated and will be removed in urllib3 v2.1.0. Instead access HTTPResponse.headers directly.
    return self.urllib3_response.getheaders()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================== 1 passed, 1 warning in 76.32s (0:01:16) ===================================================================
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.